### PR TITLE
Fixed table locale setting for de and included jp locale for tables

### DIFF
--- a/src/table.cpp
+++ b/src/table.cpp
@@ -214,9 +214,17 @@ void XLELib::Table::clean() {
 void XLELib::Table::set_table_locale(std::string loc) {
 	if(loc == "de") {
 		#ifdef _WIN32
-			locale = "german-de";
+			locale = "iso-8859-1";
 		#else
-			locale = "de_DE.UTF-8";
+			locale = "de_DE.ISO-8859-1";
+		#endif
+		return;
+	}
+	if(loc == "jp") {
+		#ifdef _WIN32
+			locale = "shift_jis";
+		#else
+			locale = "ja_JP.EUC-JP";
 		#endif
 		return;
 	}


### PR DESCRIPTION
The locale settings for german (de) tables wasn't working because it was set to `UTF-8` instead of `ISO`. `ISO` was already in use for translation tables. This change replaces the wrong `UTF-8` locale.

Tables had no locale setting for japanese (jp) files. This change adds the locale setting from the translation tables to the normal tables as well.